### PR TITLE
Fixed chrome image rendering for Homepage widget.

### DIFF
--- a/inc/libraries/widgets/widget-newspaper-x-header-module/layouts/default.php
+++ b/inc/libraries/widgets/widget-newspaper-x-header-module/layouts/default.php
@@ -32,7 +32,7 @@
 				?>
                 <li class="blazy" id="newspaper-x-recent-post-<?php echo $i; ?>"
                     data-src="<?php echo esc_url( $image ) ?>"
-                    style="background-image:url('<?php echo esc_url( $placeholder ) ?>')">
+                    style="background-image:url('<?php echo esc_url( $image ) ?>')">
                     <div class="newspaper-x-post-info">
                         <<?php echo $h; ?>>
                         <a href="<?php echo esc_url( get_permalink( get_the_ID() ) ) ?>">


### PR DESCRIPTION
In chrome browser data-src wasn't picked up correctly on images and showing low resolution images in "header widget".

Instead of loading $placeholder it's better to load full path of image.